### PR TITLE
Add services section

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@ TODO:
         <nav class="dot-nav">
             <a href="#hero" class="dot active" data-section="hero"></a>
             <a href="#about" class="dot" data-section="about"></a>
+            <a href="#services" class="dot" data-section="services"></a>
             <a href="#staff" class="dot" data-section="staff"></a>
             <a href="#gallery" class="dot" data-section="gallery"></a>
             <a href="#contact" class="dot" data-section="contact"></a>
@@ -65,6 +66,7 @@ TODO:
                         -->  
                         <a href="#">Story</a>
                         <a href="#">Staff</a>
+                        <a href="#services">Services</a>
                         <a href="#">Contact</a>
                         <a href="#">Testimonials</a>
 
@@ -155,6 +157,32 @@ TODO:
 
 
 
+
+    <section id="services" class="snap-section services-section">
+        <div class="wrapper">
+
+            <hgroup>
+                <h2 class="glitch" data-text="SERVICES">SERVICES</h2>
+                <p class="newsletter-text___NOT">WHAT WE DO</p>
+            </hgroup>
+
+            <div class="services-grid">
+                <article class="service-card">
+                    <h3 class="service-title">UX DESIGN</h3>
+                    <p class="service-desc">Brutally simple user experiences.</p>
+                </article>
+                <article class="service-card">
+                    <h3 class="service-title">BRANDING</h3>
+                    <p class="service-desc">Bold visual identities that hit hard.</p>
+                </article>
+                <article class="service-card">
+                    <h3 class="service-title">DEVELOPMENT</h3>
+                    <p class="service-desc">Fast and accessible web solutions.</p>
+                </article>
+            </div>
+
+        </div> <!-- /wrapper -->
+    </section>
 
     <section id="staff" class="snap-section staff-section">
         <div class="wrapper">
@@ -403,11 +431,12 @@ TODO:
 
 
     <div class="scroll-indicator">
-        <div class="scroll-dot active" data-section="hero"></div>
-        <div class="scroll-dot" data-section="about"></div>
-        <div class="scroll-dot" data-section="gallery"></div>
-        <div class="scroll-dot" data-section="staff"></div>
-        <div class="scroll-dot" data-section="contact"></div>
+    <div class="scroll-dot active" data-section="hero"></div>
+    <div class="scroll-dot" data-section="about"></div>
+    <div class="scroll-dot" data-section="services"></div>
+    <div class="scroll-dot" data-section="gallery"></div>
+    <div class="scroll-dot" data-section="staff"></div>
+    <div class="scroll-dot" data-section="contact"></div>
     </div>
     
     <script>

--- a/style.css
+++ b/style.css
@@ -653,6 +653,48 @@ marquee /* ,
     }
 
 
+/*
+ * SERVICES
+ */
+
+.services-section {
+    padding: 4rem 2rem;
+    background: var(--c-bg);
+}
+
+.services-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 4em;
+}
+
+.service-card {
+    background: var(--c-bg-alt);
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 2rem;
+    box-shadow: var(--box-shadow);
+    transition: transform 0.2s ease;
+}
+
+.service-card:hover {
+    transform: translate(-5px, -5px);
+    box-shadow: 10px 10px var(--border-color);
+}
+
+.service-title {
+    font-size: 1.618em;
+    font-weight: 800;
+    margin-bottom: 1rem;
+    color: var(--c-text);
+}
+
+.service-desc {
+    font-size: 1em;
+    color: var(--c-text);
+}
+
+
 
 
 


### PR DESCRIPTION
## Summary
- add services section showcasing design, branding and development offerings
- extend navigation dots and scroll indicator for services section
- style services section with neobrutalist card layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b96eb3fd3083269789413c2bbb2518