### PR TITLE
Add search popover and footer contact info

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <!-- <meta name="viewport" content="width=device-width, initial-scale=1.0"> -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://s.w.org/wp-includes/css/dashicons.css">
     <title>A Neobrutalism Demo</title>
     <meta name="description" content="A very simple neobrutalism ui trend demo">
     <meta name="keywords" content="CSS, UI, Design Trend">
@@ -77,6 +78,19 @@ TODO:
                         <a href="#">LIGHT</a>
                         <a href="#">DARK</a>
                     </menu>
+
+                    <div class="header-search">
+                        <button id="search-toggle" class="search-toggle" aria-label="Search">
+                            <span class="dashicons dashicons-search"></span>
+                        </button>
+                        <div id="search-popover" class="search-popover">
+                            <form class="search-form">
+                                <label for="search-field" class="screen-reader-text">Search</label>
+                                <input type="search" id="search-field" placeholder="Search...">
+                                <button type="submit">Go</button>
+                            </form>
+                        </div>
+                    </div>
 
                 </div> <!-- /inner -->
             </div> <!-- /wrapper -->
@@ -432,6 +446,10 @@ TODO:
                 <a href="#">TWITTER</a>
                 <a href="#">BEHANCE</a>
             </div>
+            <div class="footer-item">
+                <h3>CONTACT</h3>
+                <p>123 Brutal Ave<br>Nowhere City<br>Phone: (123) 456-7890<br>Email: info@brutal.example</p>
+            </div>
         </div>
         <div class="footer-bottom">
             <p>© BRUTAL DESIGN 2024</p>
@@ -528,8 +546,16 @@ TODO:
                 dot.classList.toggle('active', dot.dataset.section === sectionId);
             });
         }
-    });    
+    });
 </script>
-    
+
+<script>
+    const searchToggle = document.getElementById('search-toggle');
+    const searchPopover = document.getElementById('search-popover');
+    searchToggle.addEventListener('click', () => {
+        searchPopover.classList.toggle('active');
+    });
+</script>
+
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -559,11 +559,11 @@ marquee /* ,
 
 .footer-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 40px;
 
     /* padding-block: 6em; */
-    padding-block: 4em; 
+    padding-block: 4em;
 }
 
 .footer-item a {
@@ -1303,4 +1303,50 @@ marquee /* ,
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow);
     padding: 2rem;
+}
+
+/* Search popover in header */
+.header-search {
+    position: relative;
+}
+
+.search-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--c-text);
+    font-size: 24px;
+}
+
+.search-popover {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: var(--c-bg);
+    color: var(--c-text);
+    padding: 1em;
+    box-shadow: var(--box-shadow);
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: var(--border-radius);
+}
+
+.search-popover.active {
+    display: block;
+}
+
+.search-popover input[type="search"] {
+    padding: 0.5em;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    background: var(--c-bg-alt);
+    color: var(--c-text);
+}
+
+.search-popover button {
+    margin-left: 0.5em;
+    padding: 0.5em 1em;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    background: var(--c-bg-alt);
+    color: var(--c-text);
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- add dashicons search toggle in header with popover search form
- include dummy contact information in footer and update grid layout
- style search popover and footer grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ab87bc7c83268381c5b1bfe343f2