### PR TITLE
Add mobile slider for testimonials

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,40 +365,51 @@ TODO:
                 <p>DON'T BELIEVE EVERYTHING THEY SAY</p>
             </hgroup>
 
-            <div class="testimonials-grid">
-                <article class="testimonial-card">
-                    <p class="testimonial-quote">"Their brutal approach to design completely transformed our brand. Bold, unapologetic, and exactly what we needed."</p>
-                    <div class="testimonial-author">
-                        <img src="https://picsum.photos/200" alt="Client" class="author-image">
-                        <div class="author-info">
-                            <div class="author-name">SARAH PARKER</div>
-                            <div class="author-role">CEO, TECH CO</div>
-                        </div>
+            <div class="testimonials-slider">
+                <button class="testimonial-nav prev" type="button" aria-label="Previous testimonial">
+                    <span class="dashicons dashicons-arrow-left-alt2"></span>
+                </button>
+                <div class="testimonials-viewport">
+                    <div class="testimonials-track testimonials-grid">
+                        <article class="testimonial-card">
+                            <p class="testimonial-quote">"Their brutal approach to design completely transformed our brand. Bold, unapologetic, and exactly what we needed."</p>
+                            <div class="testimonial-author">
+                                <img src="https://picsum.photos/200" alt="Client" class="author-image">
+                                <div class="author-info">
+                                    <div class="author-name">SARAH PARKER</div>
+                                    <div class="author-role">CEO, TECH CO</div>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="testimonial-card">
+                            <p class="testimonial-quote">"Breaking conventions never looked so good. Our website traffic increased by 200% after the redesign."</p>
+                            <div class="testimonial-author">
+                                <img src="https://picsum.photos/201" alt="Client" class="author-image">
+                                <div class="author-info">
+                                    <div class="author-name">MARK JOHNSON</div>
+                                    <div class="author-role">MARKETING DIR</div>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="testimonial-card">
+                            <p class="testimonial-quote">"Finally, a design agency that understands the power of raw aesthetics. Outstanding work!"</p>
+                            <div class="testimonial-author">
+                                <img src="https://picsum.photos/202" alt="Client" class="author-image">
+                                <div class="author-info">
+                                    <div class="author-name">LISA ZHANG</div>
+                                    <div class="author-role">CREATIVE LEAD</div>
+                                </div>
+                            </div>
+                        </article>
                     </div>
-                </article>
-        
-                <article class="testimonial-card">
-                    <p class="testimonial-quote">"Breaking conventions never looked so good. Our website traffic increased by 200% after the redesign."</p>
-                    <div class="testimonial-author">
-                        <img src="https://picsum.photos/201" alt="Client" class="author-image">
-                        <div class="author-info">
-                            <div class="author-name">MARK JOHNSON</div>
-                            <div class="author-role">MARKETING DIR</div>
-                        </div>
-                    </div>
-                </article>
-        
-                <article class="testimonial-card">
-                    <p class="testimonial-quote">"Finally, a design agency that understands the power of raw aesthetics. Outstanding work!"</p>
-                    <div class="testimonial-author">
-                        <img src="https://picsum.photos/202" alt="Client" class="author-image">
-                        <div class="author-info">
-                            <div class="author-name">LISA ZHANG</div>
-                            <div class="author-role">CREATIVE LEAD</div>
-                        </div>
-                    </div>
-                </article>
+                </div>
+                <button class="testimonial-nav next" type="button" aria-label="Next testimonial">
+                    <span class="dashicons dashicons-arrow-right-alt2"></span>
+                </button>
             </div>
+            <div class="testimonial-dots" aria-label="Testimonial navigation"></div>
 
         </div> <!-- /wrapper -->
     </section>
@@ -554,6 +565,128 @@ TODO:
     const searchPopover = document.getElementById('search-popover');
     searchToggle.addEventListener('click', () => {
         searchPopover.classList.toggle('active');
+    });
+</script>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const slider = document.querySelector('.testimonials-slider');
+        const viewport = slider?.querySelector('.testimonials-viewport');
+        const track = slider?.querySelector('.testimonials-track');
+        const prevButton = slider?.querySelector('.testimonial-nav.prev');
+        const nextButton = slider?.querySelector('.testimonial-nav.next');
+        const dotsContainer = document.querySelector('.testimonial-dots');
+
+        if (!slider || !viewport || !track || !prevButton || !nextButton || !dotsContainer) {
+            return;
+        }
+
+        const slides = Array.from(track.children);
+        if (!slides.length) {
+            return;
+        }
+
+        let activeIndex = 0;
+        let isEnabled = false;
+        let dots = [];
+
+        const updateButtons = () => {
+            prevButton.disabled = activeIndex === 0;
+            nextButton.disabled = activeIndex === slides.length - 1;
+            dots.forEach((dot, index) => {
+                const isActive = index === activeIndex;
+                dot.classList.toggle('active', isActive);
+                dot.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
+        };
+
+        const updateTransform = () => {
+            if (!isEnabled) {
+                return;
+            }
+            const viewportWidth = viewport.getBoundingClientRect().width;
+            track.style.transform = `translateX(-${activeIndex * viewportWidth}px)`;
+        };
+
+        const goTo = (index) => {
+            activeIndex = Math.max(0, Math.min(index, slides.length - 1));
+            updateTransform();
+            updateButtons();
+        };
+
+        const buildDots = () => {
+            dotsContainer.innerHTML = '';
+            dots = slides.map((_, index) => {
+                const dot = document.createElement('button');
+                dot.type = 'button';
+                dot.className = 'testimonial-dot';
+                dot.setAttribute('aria-label', `Show testimonial ${index + 1}`);
+                dot.addEventListener('click', () => goTo(index));
+                dotsContainer.appendChild(dot);
+                return dot;
+            });
+        };
+
+        const enable = () => {
+            if (isEnabled) {
+                return;
+            }
+            isEnabled = true;
+            track.style.transition = 'transform 0.4s ease';
+            buildDots();
+            goTo(0);
+        };
+
+        const disable = () => {
+            if (!isEnabled) {
+                return;
+            }
+            isEnabled = false;
+            track.style.transform = '';
+            track.style.transition = '';
+            dotsContainer.innerHTML = '';
+            dots = [];
+            prevButton.disabled = false;
+            nextButton.disabled = false;
+        };
+
+        prevButton.addEventListener('click', () => {
+            if (!isEnabled) {
+                return;
+            }
+            goTo(activeIndex - 1);
+        });
+
+        nextButton.addEventListener('click', () => {
+            if (!isEnabled) {
+                return;
+            }
+            goTo(activeIndex + 1);
+        });
+
+        const mediaQuery = window.matchMedia('(max-width: 768px)');
+
+        const handleChange = (event) => {
+            if (event.matches) {
+                enable();
+            } else {
+                disable();
+            }
+        };
+
+        if (typeof mediaQuery.addEventListener === 'function') {
+            mediaQuery.addEventListener('change', handleChange);
+        } else if (typeof mediaQuery.addListener === 'function') {
+            mediaQuery.addListener(handleChange);
+        }
+
+        handleChange(mediaQuery);
+
+        window.addEventListener('resize', () => {
+            if (isEnabled) {
+                updateTransform();
+            }
+        });
     });
 </script>
 

--- a/style.css
+++ b/style.css
@@ -1223,6 +1223,51 @@ marquee /* ,
     */
 }
 
+.testimonials-slider {
+    display: flex;
+    align-items: stretch;
+    gap: 1.5rem;
+}
+
+.testimonials-viewport {
+    flex: 1;
+}
+
+.testimonials-track {
+    width: 100%;
+}
+
+.testimonial-nav {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    background: var(--c-accent);
+    color: var(--c-text);
+    box-shadow: var(--box-shadow);
+    cursor: pointer;
+    font-size: 1.5rem;
+    line-height: 1;
+    transition: transform 0.2s ease;
+}
+
+.testimonial-nav:hover:not(:disabled) {
+    transform: translate(-5px, -5px);
+}
+
+.testimonial-nav:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.testimonial-dots {
+    display: none;
+}
+
 .testimonial-card {
     position: relative;
     padding: 2rem;
@@ -1350,3 +1395,58 @@ marquee /* ,
     color: var(--c-text);
     cursor: pointer;
 }
+
+@media (max-width: 768px) {
+
+    .testimonials-track {
+        display: flex;
+        gap: 0;
+        transition: transform 0.4s ease;
+    }
+
+    .testimonials-track .testimonial-card {
+        flex: 0 0 100%;
+    }
+
+    .testimonials-viewport {
+        overflow: hidden;
+    }
+
+    .testimonials-slider {
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .testimonial-nav {
+        display: inline-flex;
+        flex-shrink: 0;
+    }
+
+    .testimonial-dots {
+        display: flex;
+        justify-content: center;
+        gap: 0.75rem;
+        margin-top: 2rem;
+    }
+
+    .testimonial-dot {
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        border: var(--border-width) var(--border-style) var(--border-color);
+        background: var(--c-bg);
+        box-shadow: var(--box-shadow);
+        cursor: pointer;
+        transition: transform 0.2s ease;
+    }
+
+    .testimonial-dot.active {
+        background: var(--c-accent);
+    }
+
+    .testimonial-dot:focus-visible {
+        outline: 3px solid var(--c-accent);
+        outline-offset: 2px;
+    }
+}
+


### PR DESCRIPTION
## Summary
- wrap the testimonials in a slider structure with navigation buttons and dots
- add responsive styles so the slider controls appear on small screens while preserving the desktop grid layout
- implement JavaScript to activate the slider only on mobile viewports and keep the UI in sync when navigating

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc2292f0fc8326bd44b9194eaae2e0