### PR TITLE
Add functional theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,8 +75,10 @@ TODO:
 
                     </nav>
                     <menu class="">
-                        <a href="#">LIGHT</a>
-                        <a href="#">DARK</a>
+                        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" data-theme="light">
+                            <span class="theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true">☀️</span>
+                            <span class="theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true">🌙</span>
+                        </button>
                     </menu>
 
                     <div class="header-search">
@@ -555,6 +557,50 @@ TODO:
     searchToggle.addEventListener('click', () => {
         searchPopover.classList.toggle('active');
     });
+</script>
+
+<script>
+    (function () {
+        const STORAGE_KEY = 'theme-preference';
+        const body = document.body;
+        const toggle = document.getElementById('theme-toggle');
+
+        if (!toggle) {
+            return;
+        }
+
+        const getStoredTheme = () => {
+            try {
+                return localStorage.getItem(STORAGE_KEY);
+            } catch (err) {
+                return null;
+            }
+        };
+
+        const storeTheme = (theme) => {
+            try {
+                localStorage.setItem(STORAGE_KEY, theme);
+            } catch (err) {
+                /* noop */
+            }
+        };
+
+        const applyTheme = (theme) => {
+            const isDark = theme === 'dark';
+            body.classList.toggle('theme-dark', isDark);
+            toggle.dataset.theme = isDark ? 'dark' : 'light';
+            toggle.setAttribute('aria-pressed', String(isDark));
+        };
+
+        const preferredTheme = getStoredTheme() || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        applyTheme(preferredTheme);
+
+        toggle.addEventListener('click', () => {
+            const nextTheme = body.classList.contains('theme-dark') ? 'light' : 'dark';
+            applyTheme(nextTheme);
+            storeTheme(nextTheme);
+        });
+    })();
 </script>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -30,22 +30,31 @@
     --border-radius: 8px;
     /* --border-radius: 0px; */
     --box-shadow: 5px 5px black;
-    
-    
+
+
 }
 
 
 
-body { 
-    background: var(--c-text); /* ??? */
+body {
+    background: var(--c-bg);
     font-family: var(--ff);
     font-weight: bold;
     /*
     color: var(--c-bg);
     color: black;
     */
-    color: var(--c-text);    
+    color: var(--c-text);
     line-height: 1.6;
+}
+
+body.theme-dark {
+    --c-text: #f4f4f0;
+    --c-bg: #1b1733;
+    --c-bg-alt: #312a54;
+    --c-accent: #ffef5c;
+    --border-color: #f4f4f0;
+    --box-shadow: 5px 5px #f4f4f0;
 }
 
 
@@ -128,6 +137,46 @@ menu {
 
     }    
 
+}
+
+.theme-toggle {
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: 100vh;
+    background: var(--c-bg-alt);
+    color: var(--c-text);
+    font-family: inherit;
+    font-size: 20px;
+    font-weight: bold;
+    padding: 0.5em 1em;
+    box-shadow: var(--box-shadow);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.theme-toggle:focus {
+    outline: 3px solid var(--c-accent);
+    outline-offset: 4px;
+}
+
+.theme-toggle:hover {
+    transform: translate(-5px, -5px);
+    box-shadow: 5px 5px 0 var(--border-color);
+}
+
+.theme-toggle__icon {
+    font-size: 1.2em;
+    line-height: 1;
+}
+
+.theme-toggle[data-theme="dark"] .theme-toggle__icon--sun {
+    display: none;
+}
+
+.theme-toggle[data-theme="light"] .theme-toggle__icon--moon {
+    display: none;
 }
 
 


### PR DESCRIPTION
## Summary
- replace the placeholder light/dark links with a single toggle button that switches between sun and moon icons
- persist the selected theme and respect the user's system preference when loading the page
- define shared light and dark theme variables so the palette updates across the layout when toggled

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc22c82fb88326834a774fe15ade0f