### PR TITLE
Add mobile hamburger menu overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,12 +60,12 @@ TODO:
 
                     <img class="logo" src="img/logoipsum-332.svg" alt="Brutal Design Logo">
                     <nav class="nav">
-                        <!-- 
+                        <!--
                         <a href="#">HOME</a>
                         <a href="#">ABOUT</a>
                         <a href="#">WORK</a>
                         <a href="#">CONTACT</a>
-                        -->  
+                        -->
                         <a href="#">Story</a>
                         <a href="#">Staff</a>
                         <a href="#services">Services</a>
@@ -74,6 +74,11 @@ TODO:
 
 
                     </nav>
+                    <button class="menu-toggle" type="button" aria-expanded="false" aria-label="Open menu">
+                        <span class="menu-toggle__bar"></span>
+                        <span class="menu-toggle__bar"></span>
+                        <span class="menu-toggle__bar"></span>
+                    </button>
                     <menu class="">
                         <a href="#">LIGHT</a>
                         <a href="#">DARK</a>
@@ -557,5 +562,49 @@ TODO:
     });
 </script>
 
+    <script>
+        (function () {
+            const menuToggle = document.querySelector('.menu-toggle');
+            const nav = document.querySelector('.nav');
+            const body = document.body;
+            if (!menuToggle || !nav) {
+                return;
+            }
+
+            const updateAria = (isOpen) => {
+                menuToggle.setAttribute('aria-expanded', String(isOpen));
+                menuToggle.setAttribute('aria-label', isOpen ? 'Close menu' : 'Open menu');
+            };
+
+            menuToggle.addEventListener('click', () => {
+                const isOpen = body.classList.toggle('menu-open');
+                updateAria(isOpen);
+            });
+
+            nav.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', () => {
+                    if (!body.classList.contains('menu-open')) {
+                        return;
+                    }
+                    body.classList.remove('menu-open');
+                    updateAria(false);
+                });
+            });
+
+            const mediaQuery = window.matchMedia('(min-width: 769px)');
+            const handleWidthChange = (event) => {
+                if (event.matches && body.classList.contains('menu-open')) {
+                    body.classList.remove('menu-open');
+                    updateAria(false);
+                }
+            };
+
+            if (mediaQuery.addEventListener) {
+                mediaQuery.addEventListener('change', handleWidthChange);
+            } else {
+                mediaQuery.addListener(handleWidthChange);
+            }
+        })();
+    </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -130,6 +130,37 @@ menu {
 
 }
 
+.menu-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: 100vh;
+    background-color: var(--c-bg-alt);
+    box-shadow: var(--box-shadow);
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.menu-toggle:hover {
+    transform: translate(-5px, -5px);
+}
+
+.menu-toggle__bar {
+    display: block;
+    width: 60%;
+    height: 4px;
+    border-radius: 100vh;
+    background-color: var(--c-text);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.menu-toggle__bar + .menu-toggle__bar {
+    margin-top: 6px;
+}
+
 
 
 @media (max-width: 1024px) {
@@ -138,19 +169,82 @@ menu {
     menu {
         gap: 2em;
         gap: 1em;
-    
+
         a {
 
             font-size: 24px;
             font-size: 20px;
             /* padding: 0.5em 1em; */
-        
 
-            
-    
-    
-        }    
-    
+
+
+
+
+        }
+
+    }
+
+}
+
+@media (max-width: 768px) {
+
+    header {
+        position: relative;
+    }
+
+    header .inner {
+        justify-content: space-between;
+        gap: 1.5em;
+    }
+
+    .menu-toggle {
+        display: inline-flex;
+        flex-direction: column;
+        z-index: 1002;
+    }
+
+    nav.nav {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background-color: var(--c-bg);
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 2em;
+        padding: 2em;
+        z-index: 1000;
+    }
+
+    nav.nav a {
+        font-size: clamp(28px, 8vw, 40px);
+        width: 100%;
+        text-align: center;
+    }
+
+    body.menu-open nav.nav {
+        display: flex;
+    }
+
+    body.menu-open {
+        overflow: hidden;
+    }
+
+    body.menu-open .menu-toggle__bar:nth-child(1) {
+        transform: translateY(10px) rotate(45deg);
+    }
+
+    body.menu-open .menu-toggle__bar:nth-child(2) {
+        opacity: 0;
+    }
+
+    body.menu-open .menu-toggle__bar:nth-child(3) {
+        transform: translateY(-10px) rotate(-45deg);
+    }
+
+    menu,
+    .header-search {
+        display: none;
     }
 
 }


### PR DESCRIPTION
## Summary
- add a hamburger toggle button to the header navigation for small screens
- create a fullscreen mobile navigation overlay and disable scroll while it is open
- close the overlay when resizing to desktop or selecting a menu link for better UX

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc2305ae5083268dfdc35ada618b29