### PR TITLE
Add styleguide page with UI element examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,7 +452,7 @@ TODO:
             </div>
         </div>
         <div class="footer-bottom">
-            <p>© BRUTAL DESIGN 2024</p>
+            <p>© BRUTAL DESIGN 2024 · <a href="styleguide.html">STYLEGUIDE</a></p>
         </div>
     </footer>
 

--- a/style.css
+++ b/style.css
@@ -1350,3 +1350,226 @@ marquee /* ,
     color: var(--c-text);
     cursor: pointer;
 }
+/* Styleguide page */
+body.styleguide-page {
+    background-color: var(--c-bg);
+    color: var(--c-text);
+}
+
+.styleguide-header {
+    background-color: var(--c-bg);
+    color: var(--c-text);
+    border-bottom: var(--border-width) var(--border-style) var(--border-color);
+    box-shadow: var(--box-shadow);
+}
+
+.styleguide-header-inner {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 3rem;
+    padding-block: 4rem;
+}
+
+.styleguide-header .eyebrow {
+    font-size: 0.875rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+}
+
+.styleguide-header .lede {
+    max-width: 36ch;
+    margin-top: 1rem;
+}
+
+.brutal-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    font-weight: bold;
+    color: var(--c-text);
+    background-color: var(--c-bg-alt);
+    padding: 0.75em 1.5em;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    box-shadow: var(--box-shadow);
+    border-radius: 100vh;
+    transition: transform 0.2s ease;
+}
+
+.brutal-link:hover {
+    transform: translate(-5px, -5px);
+}
+
+.styleguide-main {
+    padding-block: 4rem 6rem;
+}
+
+body.styleguide-page section.styleguide-section {
+    padding: 3rem;
+    margin-bottom: 3rem;
+    background-color: var(--c-bg);
+    border: var(--border-width) var(--border-style) var(--border-color);
+    box-shadow: var(--box-shadow);
+}
+
+.styleguide-section:last-of-type {
+    margin-bottom: 0;
+}
+
+.component-grid {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    margin-top: 2.5rem;
+}
+
+.component-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.component-label {
+    font-size: 0.875rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--c-text);
+}
+
+.inline-link {
+    color: var(--c-accent);
+}
+
+.styleguide-page .brutal-button {
+    width: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75em 1.5em;
+    text-decoration: none;
+}
+
+.styleguide-page .brutal-button + .brutal-button {
+    margin-top: 1rem;
+}
+
+.styleguide-page .brutal-button.outline {
+    background-color: var(--c-bg);
+}
+
+.brutal-details {
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: var(--c-bg);
+    box-shadow: var(--box-shadow);
+    padding: 1.5rem;
+}
+
+.brutal-details + .brutal-details {
+    margin-top: 1.5rem;
+}
+
+.brutal-details summary {
+    cursor: pointer;
+    font-size: 1.25rem;
+    list-style: none;
+}
+
+.brutal-details summary::-webkit-details-marker {
+    display: none;
+}
+
+.brutal-details summary::after {
+    content: "+";
+    float: right;
+}
+
+.brutal-details[open] summary::after {
+    content: "–";
+}
+
+.brutal-details p {
+    margin-top: 1rem;
+}
+
+.styleguide-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.styleguide-form label {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.styleguide-form .brutal-button {
+    align-self: flex-start;
+}
+
+.brutal-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    background-color: var(--c-bg);
+    box-shadow: var(--box-shadow);
+    border-radius: var(--border-radius);
+}
+
+.brutal-checkbox + .brutal-checkbox {
+    margin-top: 1rem;
+}
+
+.brutal-checkbox input {
+    width: 1.25rem;
+    height: 1.25rem;
+    accent-color: var(--c-text);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.styleguide-footer {
+    margin-top: 4rem;
+    background-color: transparent;
+    box-shadow: none;
+}
+
+.styleguide-footer .footer-bottom {
+    border-top: var(--border-width) var(--border-style) var(--border-color);
+    padding: 2rem 0;
+    text-align: center;
+}
+
+.styleguide-footer a {
+    color: var(--c-text);
+}
+
+@media (max-width: 768px) {
+    .styleguide-header-inner {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .styleguide-main {
+        padding-block: 3rem 4rem;
+    }
+
+    body.styleguide-page section.styleguide-section {
+        padding: 2rem;
+    }
+}

--- a/styleguide.html
+++ b/styleguide.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://s.w.org/wp-includes/css/dashicons.css">
+    <title>Styleguide · A Neobrutalism Demo</title>
+</head>
+<body class="styleguide-page">
+    <header class="styleguide-header">
+        <div class="wrapper full">
+            <div class="styleguide-header-inner">
+                <div>
+                    <p class="eyebrow">REFERENCE</p>
+                    <h1>A Neobrutalism Styleguide</h1>
+                    <p class="lede">A quick overview of the building blocks that power this demo.</p>
+                </div>
+                <a class="back-home brutal-link" href="index.html">← Back to the homepage</a>
+            </div>
+        </div>
+    </header>
+
+    <main class="styleguide-main wrapper">
+        <section class="styleguide-section">
+            <h2>Typography</h2>
+            <div class="component-grid">
+                <article class="component-card">
+                    <p class="component-label">Headings</p>
+                    <h1>Heading One</h1>
+                    <h2>Heading Two</h2>
+                    <h3>Heading Three</h3>
+                    <p>Paragraph text keeps the same bold voice as the rest of the site. <a href="#" class="inline-link">Inline links</a> lean on the accent color for emphasis.</p>
+                </article>
+                <article class="component-card">
+                    <p class="component-label">Lists</p>
+                    <ul>
+                        <li>Keep spacing generous and blocks chunky.</li>
+                        <li>Contrast matters—use the accent color thoughtfully.</li>
+                        <li>Pair bold statements with simple supporting copy.</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="styleguide-section">
+            <h2>Buttons</h2>
+            <div class="component-grid">
+                <article class="component-card">
+                    <p class="component-label">Primary actions</p>
+                    <button type="button" class="brutal-button">Standard Button</button>
+                    <a href="#" class="brutal-button as-link">Anchor Button</a>
+                </article>
+                <article class="component-card">
+                    <p class="component-label">Secondary action</p>
+                    <button type="button" class="brutal-button outline">Ghost Button</button>
+                </article>
+            </div>
+        </section>
+
+        <section class="styleguide-section">
+            <h2>Disclosure</h2>
+            <div class="component-grid">
+                <article class="component-card">
+                    <p class="component-label">Details &amp; summary</p>
+                    <details open class="brutal-details">
+                        <summary>What does the brutal look aim to achieve?</summary>
+                        <p>It embraces raw edges, unapologetic color palettes, and generous borders. Use it to make interfaces feel loud, tactile, and alive.</p>
+                    </details>
+                    <details class="brutal-details">
+                        <summary>How should spacing be handled?</summary>
+                        <p>Lean into oversized padding and obvious grid systems. The generous breathing room helps each block feel intentional.</p>
+                    </details>
+                </article>
+            </div>
+        </section>
+
+        <section class="styleguide-section">
+            <h2>Forms</h2>
+            <div class="component-grid">
+                <article class="component-card">
+                    <p class="component-label">Inputs</p>
+                    <form class="styleguide-form">
+                        <label for="sg-name">Name</label>
+                        <input id="sg-name" class="brutal-input" type="text" placeholder="Jane Doe">
+
+                        <label for="sg-email">Email</label>
+                        <input id="sg-email" class="brutal-input" type="email" placeholder="jane@example.com">
+
+                        <label for="sg-services">Service interest</label>
+                        <select id="sg-services" class="brutal-input">
+                            <option>Brand direction</option>
+                            <option>UI overhaul</option>
+                            <option>Experimental prototype</option>
+                        </select>
+
+                        <label for="sg-notes">Project notes</label>
+                        <textarea id="sg-notes" class="brutal-input" rows="4" placeholder="Tell us everything."></textarea>
+
+                        <button type="submit" class="brutal-button">Submit form</button>
+                    </form>
+                </article>
+
+                <article class="component-card">
+                    <p class="component-label">Checkboxes</p>
+                    <fieldset class="styleguide-form">
+                        <legend class="sr-only">Newsletter preferences</legend>
+                        <label class="brutal-checkbox">
+                            <input type="checkbox" checked>
+                            Weekly updates
+                        </label>
+                        <label class="brutal-checkbox">
+                            <input type="checkbox">
+                            Launch announcements
+                        </label>
+                        <label class="brutal-checkbox">
+                            <input type="checkbox" disabled>
+                            VIP waitlist
+                        </label>
+                    </fieldset>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="brutal-footer styleguide-footer">
+        <div class="footer-bottom">
+            <p>© BRUTAL DESIGN 2024 · <a href="index.html">Back home</a></p>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated styleguide page that showcases typography, buttons, disclosures, and form elements used in the demo
- extend the shared stylesheet with styleguide-specific layout, button, disclosure, and form styles
- link to the new styleguide from the site footer for easy access

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc24006bd88326860c8cc28e4b0ca7