### PR TITLE
Add Google iconography to services cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://s.w.org/wp-includes/css/dashicons.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200">
     <title>A Neobrutalism Demo</title>
     <meta name="description" content="A very simple neobrutalism ui trend demo">
     <meta name="keywords" content="CSS, UI, Design Trend">
@@ -183,14 +184,17 @@ TODO:
 
             <div class="services-grid">
                 <article class="service-card">
+                    <span class="material-symbols-outlined service-icon" aria-hidden="true">design_services</span>
                     <h3 class="service-title">UX DESIGN</h3>
                     <p class="service-desc">Brutally simple user experiences.</p>
                 </article>
                 <article class="service-card">
+                    <span class="material-symbols-outlined service-icon" aria-hidden="true">palette</span>
                     <h3 class="service-title">BRANDING</h3>
                     <p class="service-desc">Bold visual identities that hit hard.</p>
                 </article>
                 <article class="service-card">
+                    <span class="material-symbols-outlined service-icon" aria-hidden="true">code</span>
                     <h3 class="service-title">DEVELOPMENT</h3>
                     <p class="service-desc">Fast and accessible web solutions.</p>
                 </article>

--- a/style.css
+++ b/style.css
@@ -677,6 +677,15 @@ marquee /* ,
     transition: transform 0.2s ease;
 }
 
+.service-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 3rem;
+    margin-bottom: 1rem;
+    color: var(--c-accent);
+}
+
 .service-card:hover {
     transform: translate(-5px, -5px);
     box-shadow: 10px 10px var(--border-color);


### PR DESCRIPTION
## Summary
- load Google Material Symbols icon font to the page
- add a themed icon to each services card for UX, branding, and development
- style the new icons to match the neobrutalist accent color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc239720248326842cc7e82e64e404