### PR TITLE
Add light background image to hero section

### DIFF
--- a/img/hero-bg.svg
+++ b/img/hero-bg.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffd6ff"/>
+      <stop offset="50%" stop-color="#d8f3dc"/>
+      <stop offset="100%" stop-color="#cddafd"/>
+    </linearGradient>
+    <pattern id="grid" width="80" height="80" patternUnits="userSpaceOnUse">
+      <rect width="80" height="80" fill="none" stroke="#000" stroke-width="6" opacity="0.05"/>
+      <path d="M0 0L80 80" stroke="#000" stroke-width="6" opacity="0.05"/>
+      <path d="M80 0L0 80" stroke="#000" stroke-width="6" opacity="0.05"/>
+    </pattern>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad)"/>
+  <rect width="1600" height="900" fill="url(#grid)"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -208,6 +208,12 @@ section {
     /* background: #ff0000; */
     /* background: #212121; */
     background-color: var(--c-bg);
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.85)),
+        url('img/hero-bg.svg');
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
     color: var(--c-text);
 
 


### PR DESCRIPTION
## Summary
- add a soft geometric SVG asset for the hero background
- layer the hero background image with a subtle translucent gradient for readability

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cc2ccfa1488326b3b35d6b37de2a96