### PR TITLE
Enhance staff section with contacts and socials

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,16 +216,67 @@ TODO:
                     <img src="https://thispersondoesnotexist.com/image?cache=staff1" alt="Portrait of Jane Doe" class="staff-image">
                     <h3 class="staff-name">JANE DOE</h3>
                     <p class="staff-role">CREATIVE DIRECTOR</p>
+                    <a class="staff-email" href="mailto:jane.doe@example.com">jane.doe@example.com</a>
+                    <div class="staff-socials">
+                        <a href="https://instagram.com/jane_doe" aria-label="Jane Doe on Instagram">IG</a>
+                        <a href="https://dribbble.com/janedoe" aria-label="Jane Doe on Dribbble">DR</a>
+                        <a href="https://linkedin.com/in/janedoe" aria-label="Jane Doe on LinkedIn">IN</a>
+                    </div>
                 </article>
                 <article class="staff-card">
                     <img src="https://thispersondoesnotexist.com/image?cache=staff2" alt="Portrait of John Smith" class="staff-image">
                     <h3 class="staff-name">JOHN SMITH</h3>
                     <p class="staff-role">LEAD DESIGNER</p>
+                    <a class="staff-email" href="mailto:john.smith@example.com">john.smith@example.com</a>
+                    <div class="staff-socials">
+                        <a href="https://behance.net/johnsmith" aria-label="John Smith on Behance">BE</a>
+                        <a href="https://dribbble.com/johnsmith" aria-label="John Smith on Dribbble">DR</a>
+                        <a href="https://linkedin.com/in/johnsmith" aria-label="John Smith on LinkedIn">IN</a>
+                    </div>
                 </article>
                 <article class="staff-card">
                     <img src="https://thispersondoesnotexist.com/image?cache=staff3" alt="Portrait of Alex Wilson" class="staff-image">
                     <h3 class="staff-name">ALEX WILSON</h3>
                     <p class="staff-role">DEVELOPER</p>
+                    <a class="staff-email" href="mailto:alex.wilson@example.com">alex.wilson@example.com</a>
+                    <div class="staff-socials">
+                        <a href="https://github.com/alexwilson" aria-label="Alex Wilson on GitHub">GH</a>
+                        <a href="https://twitter.com/alexwilson" aria-label="Alex Wilson on Twitter">TW</a>
+                        <a href="https://linkedin.com/in/alexwilson" aria-label="Alex Wilson on LinkedIn">IN</a>
+                    </div>
+                </article>
+                <article class="staff-card">
+                    <img src="https://thispersondoesnotexist.com/image?cache=staff4" alt="Portrait of Priya Patel" class="staff-image">
+                    <h3 class="staff-name">PRIYA PATEL</h3>
+                    <p class="staff-role">OPERATIONS LEAD</p>
+                    <a class="staff-email" href="mailto:priya.patel@example.com">priya.patel@example.com</a>
+                    <div class="staff-socials">
+                        <a href="https://instagram.com/priya.patel" aria-label="Priya Patel on Instagram">IG</a>
+                        <a href="https://linkedin.com/in/priyapatel" aria-label="Priya Patel on LinkedIn">IN</a>
+                        <a href="https://twitter.com/priyapatel" aria-label="Priya Patel on Twitter">TW</a>
+                    </div>
+                </article>
+                <article class="staff-card">
+                    <img src="https://thispersondoesnotexist.com/image?cache=staff5" alt="Portrait of Luca Moretti" class="staff-image">
+                    <h3 class="staff-name">LUCA MORETTI</h3>
+                    <p class="staff-role">SOUND DESIGNER</p>
+                    <a class="staff-email" href="mailto:luca.moretti@example.com">luca.moretti@example.com</a>
+                    <div class="staff-socials">
+                        <a href="https://soundcloud.com/lucamoretti" aria-label="Luca Moretti on SoundCloud">SC</a>
+                        <a href="https://instagram.com/luca.moretti" aria-label="Luca Moretti on Instagram">IG</a>
+                        <a href="https://linkedin.com/in/lucamoretti" aria-label="Luca Moretti on LinkedIn">IN</a>
+                    </div>
+                </article>
+                <article class="staff-card">
+                    <img src="https://thispersondoesnotexist.com/image?cache=staff6" alt="Portrait of Mei Chen" class="staff-image">
+                    <h3 class="staff-name">MEI CHEN</h3>
+                    <p class="staff-role">STRATEGIST</p>
+                    <a class="staff-email" href="mailto:mei.chen@example.com">mei.chen@example.com</a>
+                    <div class="staff-socials">
+                        <a href="https://medium.com/@meichen" aria-label="Mei Chen on Medium">ME</a>
+                        <a href="https://linkedin.com/in/meichen" aria-label="Mei Chen on LinkedIn">IN</a>
+                        <a href="https://twitter.com/meichen" aria-label="Mei Chen on Twitter">TW</a>
+                    </div>
                 </article>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -666,6 +666,48 @@ marquee /* ,
         transform:
     }
 
+    .staff-email {
+        display: inline-block;
+        margin-top: 1rem;
+        font-weight: 600;
+        color: var(--c-link);
+        text-decoration: none;
+        word-break: break-all;
+    }
+
+    .staff-email:hover,
+    .staff-email:focus {
+        text-decoration: underline;
+    }
+
+    .staff-socials {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 1rem;
+    }
+
+    .staff-socials a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.875rem;
+        font-weight: 700;
+        padding: 0.4rem 0.75rem;
+        border: var(--border-width) var(--border-style) var(--border-color);
+        border-radius: var(--border-radius);
+        background: var(--c-bg);
+        color: var(--c-text);
+        text-decoration: none;
+        transition: transform 0.2s ease;
+    }
+
+    .staff-socials a:hover,
+    .staff-socials a:focus {
+        transform: translate(-2px, -2px);
+        box-shadow: 4px 4px var(--border-color);
+    }
+
 
 /*
  * SERVICES


### PR DESCRIPTION
## Summary
- expand the staff grid with three additional team members
- add direct email links and social media badges for every staff card
- style the new contact elements to match the neobrutalist aesthetic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc3e36116c8326b3525e45e92cce77