### PR TITLE
Add responsive mobile navigation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,14 @@ TODO:
                 <div class="inner">
 
                     <img class="logo" src="img/logoipsum-332.svg" alt="Brutal Design Logo">
-                    <nav class="nav">
+                    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+                        <span class="nav-toggle__bar"></span>
+                        <span class="nav-toggle__bar"></span>
+                        <span class="nav-toggle__bar"></span>
+                        <span class="screen-reader-text">Toggle navigation</span>
+                    </button>
+                    <div class="nav-group" id="primary-navigation">
+                        <nav class="nav">
                         <!-- 
                         <a href="#">HOME</a>
                         <a href="#">ABOUT</a>
@@ -74,11 +81,12 @@ TODO:
                         <a href="#">Testimonials</a>
 
 
-                    </nav>
-                    <menu class="">
+                        </nav>
+                        <menu class="">
                         <a href="#">LIGHT</a>
                         <a href="#">DARK</a>
-                    </menu>
+                        </menu>
+                    </div>
 
                     <div class="header-search">
                         <button id="search-toggle" class="search-toggle" aria-label="Search">
@@ -763,5 +771,15 @@ TODO:
     });
 </script>
 
+    <script>
+        const navToggle = document.querySelector('.nav-toggle');
+        const navGroup = document.querySelector('.nav-group');
+
+        navToggle?.addEventListener('click', () => {
+            const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+            navToggle.setAttribute('aria-expanded', String(!expanded));
+            navGroup?.classList.toggle('open', !expanded);
+        });
+    </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -12,6 +12,18 @@ a {
     text-decoration: none;
 }
 
+.screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 
 :root {
     --c-text: #000;
@@ -76,7 +88,8 @@ header {
         align-items: center;
         gap: 4em; /* PRECAUTION */
         flex-wrap: wrap; /* PRECAUTION */
-    
+        position: relative;
+
     }
 
 
@@ -143,6 +156,31 @@ menu {
 
 }
 
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    gap: 6px;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    background: var(--c-bg-alt);
+    padding: 0.75em;
+    border-radius: 12px;
+    box-shadow: var(--box-shadow);
+    cursor: pointer;
+}
+
+.nav-toggle__bar {
+    width: 24px;
+    height: 3px;
+    background: var(--c-text);
+    display: block;
+}
+
+.nav-group {
+    display: flex;
+    align-items: center;
+    gap: 2em;
+}
+
 
 
 @media (max-width: 1024px) {
@@ -166,6 +204,47 @@ menu {
     
     }
 
+}
+
+@media (max-width: 768px) {
+    .nav-toggle {
+        display: inline-flex;
+        margin-left: auto;
+    }
+
+    .nav-group {
+        position: absolute;
+        top: calc(100% + 1rem);
+        right: 0;
+        display: none;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1em;
+        background: var(--c-bg);
+        padding: 1.5em;
+        border: var(--border-width) var(--border-style) var(--border-color);
+        box-shadow: var(--box-shadow);
+        border-radius: 20px;
+        min-width: min(260px, 80vw);
+        z-index: 20;
+    }
+
+    .nav-group.open {
+        display: flex;
+    }
+
+    nav.nav,
+    menu {
+        flex-direction: column;
+        gap: 1em;
+    }
+
+    nav.nav a,
+    menu a {
+        display: block;
+        width: 100%;
+        text-align: center;
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- add a hamburger toggle button and wrapper for the primary navigation content
- style the header navigation to collapse into a dropdown menu on small screens
- include accessible helpers and script logic to toggle the mobile navigation state

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68cc4c00386483269395565b3b6f74ea