### PR TITLE
Add categorized products section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@ TODO:
             <a href="#hero" class="dot active" data-section="hero"></a>
             <a href="#about" class="dot" data-section="about"></a>
             <a href="#services" class="dot" data-section="services"></a>
+            <a href="#products" class="dot" data-section="products"></a>
             <a href="#staff" class="dot" data-section="staff"></a>
             <a href="#gallery" class="dot" data-section="gallery"></a>
             <a href="#locations" class="dot" data-section="locations"></a>
@@ -197,6 +198,82 @@ TODO:
                     <span class="material-symbols-outlined service-icon" aria-hidden="true">code</span>
                     <h3 class="service-title">DEVELOPMENT</h3>
                     <p class="service-desc">Fast and accessible web solutions.</p>
+                </article>
+            </div>
+
+        </div> <!-- /wrapper -->
+    </section>
+
+    <section id="products" class="snap-section products-section">
+        <div class="wrapper">
+
+            <hgroup>
+                <h2 class="glitch" data-text="PRODUCTS">PRODUCTS</h2>
+                <p class="newsletter-text___NOT">CURATED FOR CHAOS</p>
+            </hgroup>
+
+            <div class="product-categories" role="group" aria-label="Browse product categories">
+                <button class="product-chip" type="button">Brand Systems</button>
+                <button class="product-chip" type="button">Digital Assets</button>
+                <button class="product-chip" type="button">Merch Drops</button>
+                <button class="product-chip" type="button">Limited Editions</button>
+            </div>
+
+            <div class="products-grid">
+                <article class="product-card">
+                    <header class="product-card__header">
+                        <span class="product-category">Brand Systems</span>
+                        <span class="product-price">$2.4K</span>
+                    </header>
+                    <h3 class="product-title">Launch Identity Kit</h3>
+                    <p class="product-desc">Logo suite, typography pairings, and launch collateral ready to ship in two weeks.</p>
+                    <ul class="product-includes">
+                        <li>Full logo family + usage guide</li>
+                        <li>Social reveal pack</li>
+                        <li>Founders deck templates</li>
+                    </ul>
+                </article>
+
+                <article class="product-card">
+                    <header class="product-card__header">
+                        <span class="product-category">Digital Assets</span>
+                        <span class="product-price">$980</span>
+                    </header>
+                    <h3 class="product-title">Motion Teaser Bundle</h3>
+                    <p class="product-desc">Hypnotic loops and transitions engineered to hijack timelines.</p>
+                    <ul class="product-includes">
+                        <li>8 social-ready animations</li>
+                        <li>Audio-reactive stingers</li>
+                        <li>Editable source files</li>
+                    </ul>
+                </article>
+
+                <article class="product-card">
+                    <header class="product-card__header">
+                        <span class="product-category">Merch Drops</span>
+                        <span class="product-price">$65</span>
+                    </header>
+                    <h3 class="product-title">Hyperbold Capsule Tee</h3>
+                    <p class="product-desc">Hand-pulled screen print, heavyweight cotton, unapologetic palette.</p>
+                    <ul class="product-includes">
+                        <li>Limited run of 150</li>
+                        <li>Custom woven labels</li>
+                        <li>Ships with neon manifesto</li>
+                    </ul>
+                </article>
+
+                <article class="product-card">
+                    <header class="product-card__header">
+                        <span class="product-category">Limited Editions</span>
+                        <span class="product-price">$420</span>
+                    </header>
+                    <h3 class="product-title">Poster Triptych Series</h3>
+                    <p class="product-desc">Riso printed on oversized stock. Each set hand-numbered and signed.</p>
+                    <ul class="product-includes">
+                        <li>Three 24" × 36" prints</li>
+                        <li>Certificate of chaos</li>
+                        <li>Archival packaging</li>
+                    </ul>
                 </article>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -764,6 +764,99 @@ marquee /* ,
     color: var(--c-text);
 }
 
+.products-section {
+    padding: 4rem 2rem;
+    background: var(--c-bg);
+}
+
+.product-categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin: 2rem 0 3rem;
+}
+
+.product-chip {
+    font: inherit;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding: 0.75rem 1.5rem;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: 100vmax;
+    background: var(--c-bg-alt);
+    color: var(--c-text);
+    box-shadow: var(--box-shadow);
+    transition: transform 0.2s ease;
+    cursor: pointer;
+}
+
+.product-chip:hover,
+.product-chip:focus {
+    transform: translate(-4px, -4px);
+    box-shadow: 8px 8px var(--border-color);
+}
+
+.products-grid {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.product-card {
+    background: var(--c-bg-alt);
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 2.5rem 2rem;
+    box-shadow: var(--box-shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.product-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.product-category {
+    padding: 0.35rem 0.75rem;
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: 100vmax;
+    background: var(--c-bg);
+}
+
+.product-price {
+    font-size: 1.25rem;
+    font-weight: 800;
+    color: var(--c-text);
+}
+
+.product-title {
+    font-size: 1.618em;
+    line-height: 1.1;
+}
+
+.product-desc {
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+.product-includes {
+    display: grid;
+    gap: 0.5rem;
+    padding-left: 1.25rem;
+    font-size: 0.95rem;
+}
+
+.product-includes li::marker {
+    color: var(--c-text);
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- add a homepage products section with navigation dot and category chips for quick browsing
- populate the section with four curated product offerings including pricing and inclusions
- style the new product section with neobrutalist treatments for chips, cards, and layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc4c8512448326a9ec189210fbf89a