### PR TITLE
Adjust header layout for 1024px hamburger activation

### DIFF
--- a/style.css
+++ b/style.css
@@ -89,9 +89,8 @@ header {
     .inner {
         display: flex;
         justify-content: space-between;
-        justify-content: flex-end;
         align-items: center;
-        gap: 4em; /* PRECAUTION */
+        gap: 2.5em;
         flex-wrap: wrap; /* PRECAUTION */
         position: relative;
 
@@ -249,31 +248,18 @@ menu {
 
 @media (max-width: 1024px) {
 
-    nav.nav,
-    menu {
-        gap: 2em;
-        gap: 1em;
-    
-        a {
-
-            font-size: 24px;
-            font-size: 20px;
-            /* padding: 0.5em 1em; */
-        
-
-            
-    
-    
-        }    
-    
+    header .inner {
+        flex-wrap: nowrap;
+        gap: 1.5em;
     }
 
-}
-
-@media (max-width: 768px) {
     .nav-toggle {
         display: inline-flex;
         margin-left: auto;
+    }
+
+    .header-search {
+        display: none;
     }
 
     .nav-group {


### PR DESCRIPTION
## Summary
- update the header flex layout so the logo and responsive controls stay on one row
- show the hamburger toggle at 1024px and convert the navigation stack into a popover menu while hiding the search button on smaller viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc5b959b3c832694437b6a85611080