### PR TITLE
Add founder inspiration section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@ TODO:
         <nav class="dot-nav">
             <a href="#hero" class="dot active" data-section="hero"></a>
             <a href="#about" class="dot" data-section="about"></a>
+            <a href="#founder" class="dot" data-section="founder"></a>
             <a href="#services" class="dot" data-section="services"></a>
             <a href="#products" class="dot" data-section="products"></a>
             <a href="#staff" class="dot" data-section="staff"></a>
@@ -182,6 +183,39 @@ TODO:
 
 
 
+
+
+    <section id="founder" class="snap-section founder-section">
+        <div class="wrapper">
+            <div class="founder-grid">
+                <div class="founder-message">
+                    <p class="section-label">FROM THE FOUNDER</p>
+                    <h2>We build loud stages for the quietest, boldest ideas.</h2>
+                    <p>
+                        This studio was never meant to be a safe choice. It was born so misfits, dreamers, and rebels had a
+                        place to turn their wildest drafts into living, breathing experiences. Every project we touch is an
+                        invitation to stand for something—brighter, sharper, and unmistakably yours.
+                    </p>
+                    <ul class="founder-pillars">
+                        <li><span aria-hidden="true">★</span> Design with unapologetic honesty.</li>
+                        <li><span aria-hidden="true">★</span> Protect the spark that makes you different.</li>
+                        <li><span aria-hidden="true">★</span> Leave the internet louder than you found it.</li>
+                    </ul>
+                    <div class="founder-signoff">
+                        <p class="signoff-name">Jane Doe</p>
+                        <p class="signoff-title">Founder &amp; Creative Director</p>
+                    </div>
+                </div>
+                <div class="founder-visual" aria-hidden="true">
+                    <div class="manifesto-card">
+                        <p class="manifesto-title">Manifesto 01</p>
+                        <p class="manifesto-body">Make the bold feel inevitable. Make the inevitable feel human.</p>
+                        <p class="manifesto-footer">EST. 2024 — BRUTAL STUDIO</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
 
 
     <section id="services" class="snap-section services-section">
@@ -703,6 +737,7 @@ TODO:
     <div class="scroll-indicator">
     <div class="scroll-dot active" data-section="hero"></div>
     <div class="scroll-dot" data-section="about"></div>
+    <div class="scroll-dot" data-section="founder"></div>
     <div class="scroll-dot" data-section="services"></div>
     <div class="scroll-dot" data-section="staff"></div>
     <div class="scroll-dot" data-section="gallery"></div>

--- a/style.css
+++ b/style.css
@@ -873,6 +873,151 @@ marquee /* ,
 
 
 /*
+ * FOUNDER MESSAGE
+ */
+
+.founder-section {
+    padding: 6rem 2rem;
+    background: var(--c-bg-alt);
+}
+
+.founder-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    gap: 4rem;
+    align-items: stretch;
+}
+
+.founder-message {
+    background: var(--c-bg);
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    padding: 3rem;
+    display: grid;
+    gap: 1.5rem;
+    text-transform: none;
+}
+
+.founder-message h2 {
+    font-size: clamp(2.4rem, 5vw, 3.8rem);
+    line-height: 1.1;
+    text-transform: uppercase;
+}
+
+.founder-message p {
+    font-size: 1.05rem;
+    max-width: 60ch;
+}
+
+.section-label {
+    font-size: 0.9rem;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+}
+
+.founder-pillars {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+    padding: 0;
+    margin: 1.5rem 0 0;
+}
+
+.founder-pillars li {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 1rem;
+    font-size: 1rem;
+}
+
+.founder-pillars span {
+    font-size: 1.25rem;
+    color: var(--c-accent);
+}
+
+.founder-signoff {
+    margin-top: 1.5rem;
+    display: grid;
+    gap: 0.25rem;
+    text-transform: uppercase;
+}
+
+.signoff-name {
+    font-size: 1.25rem;
+    font-weight: 800;
+}
+
+.signoff-title {
+    font-size: 0.9rem;
+    letter-spacing: 0.15em;
+}
+
+.founder-visual {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.manifesto-card {
+    background: var(--c-bg);
+    border: var(--border-width) var(--border-style) var(--border-color);
+    border-radius: calc(var(--border-radius) * 1.5);
+    box-shadow: var(--box-shadow);
+    padding: 3rem 2.5rem;
+    display: grid;
+    gap: 1.25rem;
+    text-align: left;
+    max-width: 380px;
+    transform: rotate(-2deg);
+}
+
+.manifesto-title {
+    font-size: 0.85rem;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+}
+
+.manifesto-body {
+    font-size: 1.5rem;
+    line-height: 1.3;
+    text-transform: uppercase;
+}
+
+.manifesto-footer {
+    font-size: 0.85rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+}
+
+@media (max-width: 1024px) {
+    .founder-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .founder-visual {
+        order: -1;
+    }
+
+    .manifesto-card {
+        transform: none;
+    }
+}
+
+@media (max-width: 640px) {
+    .founder-message {
+        padding: 2.25rem;
+    }
+
+    .founder-message h2 {
+        font-size: clamp(2rem, 8vw, 3rem);
+    }
+}
+
+
+/*
  * SERVICES
  */
 


### PR DESCRIPTION
## Summary
- add a "From the Founder" section to the homepage with inspirational messaging and a manifesto highlight
- update navigation indicators so the new section is included in both dot navigation areas
- create dedicated styling for the founder message layout and responsive behaviour

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc5fa4df0483269add0a404f7ba353