### PR TITLE
Make header sticky on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -165,6 +165,18 @@ header {
         top: 0;
         z-index: 10;
     }
+
+    body {
+        scroll-snap-type: none;
+        overflow: auto;
+    }
+
+    .snap-container {
+        height: auto;
+        padding-top: 0;
+        overflow: visible;
+        scroll-snap-type: none;
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- keep the header fixed to the top of the viewport on small screens
- disable scroll snapping inside the main container on mobile so the sticky header can work properly
- remove excess padding from the scroll container when using the sticky header on mobile

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc60488b188326baa42a938b6a5181