### PR TITLE
Default site theme to light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -973,7 +973,7 @@ TODO:
             themeToggleButton.setAttribute('aria-pressed', useDarkMode.toString());
         };
 
-        const initialTheme = storedTheme || (prefersDarkScheme.matches ? 'dark' : 'light');
+        const initialTheme = storedTheme || 'light';
         applyTheme(initialTheme);
 
         themeToggleButton.addEventListener('click', () => {
@@ -983,12 +983,21 @@ TODO:
             localStorage.setItem('theme', theme);
         });
 
-        prefersDarkScheme.addEventListener('change', (event) => {
-            if (!localStorage.getItem('theme')) {
-                const theme = event.matches ? 'dark' : 'light';
-                applyTheme(theme);
-            }
-        });
+        if (typeof prefersDarkScheme.addEventListener === 'function') {
+            prefersDarkScheme.addEventListener('change', (event) => {
+                if (!localStorage.getItem('theme')) {
+                    const theme = event.matches ? 'dark' : 'light';
+                    applyTheme(theme);
+                }
+            });
+        } else if (typeof prefersDarkScheme.addListener === 'function') {
+            prefersDarkScheme.addListener((event) => {
+                if (!localStorage.getItem('theme')) {
+                    const theme = event.matches ? 'dark' : 'light';
+                    applyTheme(theme);
+                }
+            });
+        }
     }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- default the initial theme selection to light mode regardless of system preference
- keep respecting stored user preferences and respond to prefers-color-scheme changes when no selection is saved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc64f984388326898e7f14c265057c