### PR TITLE
Keep theme toggle visible in mobile header

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,12 +71,12 @@ TODO:
                     </button>
                     <div class="nav-group" id="primary-navigation">
                         <nav class="nav">
-                        <!-- 
+                        <!--
                         <a href="#">HOME</a>
                         <a href="#">ABOUT</a>
                         <a href="#">WORK</a>
                         <a href="#">CONTACT</a>
-                        -->  
+                        -->
                         <a href="#">Story</a>
                         <a href="#">Staff</a>
                         <a href="#services">Services</a>
@@ -85,12 +85,12 @@ TODO:
 
 
                         </nav>
-                        <div class="theme-toggle">
-                            <button id="theme-toggle" class="theme-toggle__button" aria-label="Toggle dark mode" aria-pressed="false">
-                                <span class="material-symbols-outlined theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true">light_mode</span>
-                                <span class="material-symbols-outlined theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true">dark_mode</span>
-                            </button>
-                        </div>
+                    </div>
+                    <div class="theme-toggle">
+                        <button id="theme-toggle" class="theme-toggle__button" aria-label="Toggle dark mode" aria-pressed="false">
+                            <span class="material-symbols-outlined theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true">light_mode</span>
+                            <span class="material-symbols-outlined theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true">dark_mode</span>
+                        </button>
                     </div>
 
                     <div class="header-search">

--- a/style.css
+++ b/style.css
@@ -278,7 +278,6 @@ nav.nav a:hover {
 
     .nav-toggle {
         display: inline-flex;
-        margin-left: auto;
     }
     /*
     .header-search {
@@ -306,8 +305,7 @@ nav.nav a:hover {
         display: flex;
     }
 
-    nav.nav,
-    .theme-toggle {
+    nav.nav {
         flex-direction: column;
         gap: 1em;
     }
@@ -319,11 +317,13 @@ nav.nav a:hover {
     }
 
     .theme-toggle {
-        width: 100%;
+        order: 3;
+        margin-left: auto;
     }
 
-    .theme-toggle__button {
-        width: 100%;
+    .nav-toggle {
+        order: 4;
+        margin-left: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- move the dark mode toggle out of the collapsible navigation group so it remains in the header at all breakpoints
- adjust responsive styles to keep the toggle aligned beside the menu button while the navigation opens in a dropdown

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc6cdd2ac48326a20e9416f1265b81